### PR TITLE
fixed routes for devise users

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  #devise_for :users
+  devise_for :users
   resources :orders
   resources :products
   resources :brands


### PR DESCRIPTION
Routes for Devise Users were still broken. Fixed by uncommenting devise_for :users in routes.rb - tested ok locally.

Carlos
DamnStraight.io <== Available BTW